### PR TITLE
Lu 5843 getting variables

### DIFF
--- a/serverless.sh
+++ b/serverless.sh
@@ -3,6 +3,7 @@
 # Serverless deployment
 
 cd config-loader-deploy-repository
+npm install serverless-pseudo-parameters
 serverless plugin install --name serverless-latest-layer-version
 echo Packaging serverless bundle...
 serverless package --package pkg

--- a/serverless.sh
+++ b/serverless.sh
@@ -3,7 +3,7 @@
 # Serverless deployment
 
 cd config-loader-deploy-repository
-npm install serverless-pseudo-parameters
+serverless plugin install --name serverless-pseudo-parameters
 serverless plugin install --name serverless-latest-layer-version
 echo Packaging serverless bundle...
 serverless package --package pkg

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ provider:
   name: aws
   deploymentBucket:
     name: spp-results-sandbox-serverless
-  role: arn:aws:iam::${self:custom.accountId}:role/lambda_invoke_lambda
+  role: arn:aws:iam::#{AWS::AccountId}:role/lambda_invoke_lambda
   vpc:
     securityGroupIds:
       - ${file(../json_outputs/security_groups_output.json):SecurityGroups.0.GroupId}
@@ -34,13 +34,13 @@ functions:
       exclude:
         - ./**
     layers:
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
     environment:
       bucket_name: spp-results-sandbox
-      step_function_arn: arn:aws:states:eu-west-2:${self:custom.accountId}:stateMachine
+      step_function_arn: arn:aws:states:eu-west-2:#{AWS::AccountId}:stateMachine
       file_path: configs/
       payload_reference_name: survey
       config_suffix: _config

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,7 +21,7 @@ provider:
     individually: true
 
 custom:
-  accountId: ${env:aws_account_id}
+  accountId: #{AWS::AccountId}
 
 functions:
   deploy-config-loader:
@@ -49,3 +49,4 @@ functions:
 
 plugins:
   - serverless-latest-layer-version
+  - serverless-pseudo-parameters

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,7 +3,7 @@ service: es-config-loader
 provider:
   name: aws
   deploymentBucket:
-    name: spp-results-sandbox-serverless
+    name: spp-results-${self:custom.environment}-serverless
   role: arn:aws:iam::#{AWS::AccountId}:role/lambda_invoke_lambda
   vpc:
     securityGroupIds:
@@ -21,7 +21,7 @@ provider:
     individually: true
 
 custom:
-  accountId: #{AWS::AccountId}
+  environment: ${env:ENVIRONMENT}
 
 functions:
   deploy-config-loader:
@@ -39,7 +39,7 @@ functions:
     tags:
       app: results
     environment:
-      bucket_name: spp-results-sandbox
+      bucket_name: spp-results-${self:custom.environment}
       step_function_arn: arn:aws:states:eu-west-2:#{AWS::AccountId}:stateMachine
       file_path: configs/
       payload_reference_name: survey


### PR DESCRIPTION
This change is so that we dont pull variables out of secrets manager.
uses serverless-pseudo-parameters to get account id
AWS::Account id comes from the account being deployed to and populates when the deploy happens.

Environment and Environment type are passed in from environment variables in the pipeline.

Deployment bucket name now uses environment.(because sandbox bucket contains the word sandbox and integration bucket contains the word integration)

In step functions deploy, wranglers.json is now with the code.

All changes have been tested together in 'test-pipeline-without-secrets' in the new concourse.