### PR TITLE
Added a new helper function to retrieve account id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.devcontainer/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ payload passed in.
     payload_reference_name: The name of the refrenced used to obtain the survey code from the input JSON.
     
     step_function_arn: This is the partial arn of the step function not including the specific 
-    name so that it can be build the full arn dynamically.
+    name so that it can be build the full arn dynamically. The account_id part of the arn will be substitued at run time
+    by the config loader inserting its own account_id.
     
     config_suffix: The rest of the file name of the config files after the survey code.
     

--- a/config_loader.py
+++ b/config_loader.py
@@ -82,7 +82,7 @@ def lambda_handler(event, context):
         combined_input["location"] = combined_input["location"] + folder_id + "/"
 
         # ARN For SQS Queue.
-        constructed_arn = creating_survey_arn(step_function_arn,
+        constructed_arn = creating_survey_arn(creating_step_arn(step_function_arn),
                                               survey,
                                               survey_arn_prefix,
                                               survey_arn_suffix)
@@ -108,6 +108,19 @@ def lambda_handler(event, context):
     logger.info("Successfully completed module: " + current_module)
 
     return "done"
+
+
+def creating_step_arn(arn_segment):
+    """
+    This function will insert the account id into the arn used to reference the step
+    function.
+    :param arn_segment: Generic step function address - Type: String
+    :return String: Step Function arn with the correct account_id added
+    """
+    account_id = boto3.client('sts').get_caller_identity().get('Account')
+    arn_segment = arn_segment.replace("#{AWS::AccountId}", account_id)
+
+    return arn_segment
 
 
 def creating_survey_arn(arn_segment, survey, prefix, suffix):

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -44,9 +44,10 @@ class TestConfigLoader:
             mock_aws_functions.return_value = file.read()
             with mock.patch("config_loader.create_queue") as mock_create_queue:
                 mock_create_queue.return_value = "NotARealQueueUrl"
-
-                output = config_loader.lambda_handler(input_params, None)
-                "done" in output
+                with mock.patch("config_loader.creating_step_arn") as mock_step_arn:
+                    mock_step_arn.return_Value = "1234"
+                    output = config_loader.lambda_handler(input_params, None)
+                    "done" in output
 
     def test_creating_survey_arn(self):
         arn = config_loader.creating_survey_arn("test:arn:", "BMISG", "ES-", "-Results")
@@ -60,10 +61,10 @@ class TestConfigLoader:
             mock_aws_functions.return_value = file.read()
             with mock.patch("config_loader.create_queue") as mock_create_queue:
                 mock_create_queue.return_value = "NotARealQueueUrl"
-
-                output = config_loader.lambda_handler(input_params, None)
-
-                "done" in output
+                with mock.patch("config_loader.creating_step_arn") as mock_step_arn:
+                    mock_step_arn.return_Value = "1234"
+                    output = config_loader.lambda_handler(input_params, None)
+                    "done" in output
 
     @mock.patch("config_loader.boto3.client")
     def test_general_error(self, mock_client):


### PR DESCRIPTION
## Intro
A small change to resolve this bug: [LU-6125: Bug: Config Loader doesn't receive the correct step function arn](https://collaborate2.ons.gov.uk/jira/browse/LU-6125).

## Changes
* Added a new helper function that will take the placeholder step function arn and replace its account id with the same id as used by config loader.
* Also added the devcontainer directory to gitignore in my mission to make local vscode debugging easier in all repos as I work through them over time.