### PR TITLE
Bad exclude

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -6,7 +6,7 @@ import time
 
 import boto3
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import EXCLUDE, Schema, fields
+from marshmallow import EXCLUDE, INCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
@@ -28,7 +28,7 @@ class EnvironmentSchema(Schema):
 
 class RuntimeSchema(Schema):
     class Meta:
-        unknown = EXCLUDE
+        unknown = INCLUDE
 
     def handle_error(self, e, data, **kwargs):
         logging.error(f"Error validating runtime params: {e}")

--- a/tests/fixtures/test_config_prepared_output.json
+++ b/tests/fixtures/test_config_prepared_output.json
@@ -16,6 +16,7 @@
   "publishable_indicator": "publish",
   "explanation": "reason",
   "location": "Here01021/",
+  "RuntimeVariables": {},
   "aggA": {
     "RuntimeVariables": {
       "additional_aggregated_column": "region",


### PR DESCRIPTION
Exclude was breaking Config Loader. Fixed and due to how generic tests expect runtime variables to be structured the updated test will now ensure this functionality doesn't break again.