### PR TITLE
No longer required but kept for backwards compatibility

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -35,7 +35,7 @@ class RuntimeSchema(Schema):
         raise ValueError(f"Error validating runtime params: {e}")
 
     checkpoint = fields.Str(required=True)
-    checkpoint_file = fields.Str(required=False)
+    checkpoint_file = fields.Str()
     period = fields.Str(required=True)
     run_id = fields.Str(required=True)
     survey = fields.Str(required=True)


### PR DESCRIPTION
the snapshot_s3_uri passed from the pipeline-api lambda does a simillar job but is a URI, not a file name like this was. Future checkpointing changes might affect this further.